### PR TITLE
feat: adds XSD parsing to Schemata IDL

### DIFF
--- a/.commitlintrc
+++ b/.commitlintrc
@@ -5,7 +5,3 @@ rules:
     - 2
     - always
     - [feat, fix, chore, docs, style, refactor, test, perf, revert]
-  subject-case:
-    - 2
-    - always
-    - sentence-case

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ avro-rs = "0.13.0"
 quick-xml = "^0.27"
 log = "0.4.22"
 env_logger = "0.11.5"
+tera = "1.15.0"
+serde = { version = "1.0.215", features = ["derive"] }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "schemata",
-      "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
         "@commitlint/cli": "^19.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,5 @@
 {
   "name": "schemata",
-  "version": "0.1.0",
-  "description": "",
   "scripts": {
     "prepare": "husky",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,11 @@
-mod converter;
-mod parser;
+mod xsd;
+mod schemata;
 
+use std::fs::File;
+use std::io::BufReader;
 use clap::Parser;
+use xsd::XsdParser;
+use crate::schemata::SchemataGenerator;
 
 #[derive(Parser)]
 #[clap(version = "1.0", author = "Michael Bolton", about = "...")]
@@ -32,9 +36,39 @@ enum InputFormat {
     Avro,
 }
 
+fn handle_xsd(input: &str, output: &str) -> Result<(), Box<dyn std::error::Error>> {
+    log::info!("Parsing the XSD file {}...", input);
+    let file = File::open(input)?;
+    let reader = BufReader::new(file);
+    let schema = XsdParser::parse(reader)?;
+
+    log::info!("Generating Schemata...");
+    let generator = SchemataGenerator::new()?;
+    let schemata = generator.generate(schema)?;
+
+    log::info!("Writing the output to {}...", output);
+    std::fs::write(output, schemata)?;
+
+    log::info!("Done!");
+    Ok(())
+}
+
 fn main() {
     let cli = Cli::parse();
     env_logger::init();
 
-
+    match Commands::parse() {
+        Commands::Convert(convert) => {
+            match convert.format {
+                InputFormat::Xsd => {
+                    if let Err(e) = handle_xsd(&convert.input, &convert.output) {
+                        log::error!("Error: {}", e);
+                    }
+                }
+                _ => {
+                    log::error!("Unsupported format");
+                }
+            }
+        }
+    }
 }

--- a/src/schemata/generator.rs
+++ b/src/schemata/generator.rs
@@ -1,0 +1,85 @@
+use tera::{Context, Tera};
+use super::types::{SchemataEnum, SchemataField, SchemataNamespace, SchemataSchema};
+use crate::xsd::types::{XsdComplexType, XsdElement, XsdSchema, XsdSimpleType};
+
+
+pub struct SchemataGenerator {
+    tera: Tera,
+}
+
+impl SchemataGenerator {
+    pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        let mut tera = Tera::default();
+        tera.add_raw_template("schema", include_str!("../../templates/schemata/schema.tera"))?;
+        Ok(Self { tera })
+    }
+
+    pub fn generate(&self, xsd_schema: XsdSchema) -> Result<String, Box<dyn std::error::Error>> {
+        let mut context = Context::new();
+
+        let namespaces = self.get_namespaces(&xsd_schema);
+        context.insert("namespaces", &namespaces);
+
+        Ok(self.tera.render("schema", &context)?)
+    }
+
+    pub(crate) fn get_namespaces(&self, xsd_schema: &XsdSchema) -> Vec<SchemataNamespace> {
+        // Group schemas and enums by namespace
+        vec![SchemataNamespace {
+            name: xsd_schema.target_namespace.clone().unwrap_or_else(|| "default".to_string()),
+            schemas: self.get_schemas(&xsd_schema.complex_types),
+            enums: self.get_enums(&xsd_schema.simple_types),
+        }]
+    }
+
+    pub(crate) fn get_schemas(&self, complex_types: &[XsdComplexType]) -> Vec<SchemataSchema> {
+        complex_types.iter().map(|ct| {
+            SchemataSchema {
+                name: ct.name.clone().unwrap_or_else(|| "UnnamedSchema".to_string()),
+                comment: None,
+                fields: self.get_fields(&ct.sequence),
+            }
+        }).collect()
+    }
+
+    pub(crate) fn get_fields(&self, elements: &[XsdElement]) -> Vec<SchemataField> {
+        elements.iter().map(|e| {
+            SchemataField {
+                name: e.name.clone(),
+                type_name: e.type_name.clone().unwrap_or_else(|| "string".to_string()),
+                nullable: e.min_occurs.as_ref().map_or(false, |m| m.to_string() == "0"),
+                annotations: self.get_annotations(e),
+                comment: e.comment.clone(),
+                inline_schema: e.complex_type.as_ref().map(|ct| SchemataSchema {
+                    name: "InlineSchema".to_string(),
+                    comment: None,
+                    fields: self.get_fields(&ct.sequence),
+                }),
+            }
+        }).collect()
+    }
+
+    pub(crate) fn get_enums(&self, simple_types: &[XsdSimpleType]) -> Vec<SchemataEnum> {
+        simple_types.iter()
+            .filter_map(|st| {
+                st.restriction.as_ref().map(|r| SchemataEnum {
+                    name: st.name.clone().unwrap_or_else(|| "UnnamedEnum".to_string()),
+                    comment: None,
+                    values: r.enumeration.clone(),
+                })
+            }).collect()
+    }
+
+    pub(crate) fn get_annotations(&self, element: &XsdElement) -> String {
+        let mut annotations = Vec::new();
+
+        if let Some(min_occurs) = &element.min_occurs {
+            annotations.push(format!("@minOccurs({})", min_occurs));
+        }
+        if let Some(max_occurs) = &element.max_occurs {
+            annotations.push(format!("@maxOccurs({})", max_occurs));
+        }
+
+        annotations.join(" ")
+    }
+}

--- a/src/schemata/mod.rs
+++ b/src/schemata/mod.rs
@@ -1,0 +1,4 @@
+mod generator;
+mod tests;
+pub mod types;
+pub use generator::SchemataGenerator;

--- a/src/schemata/tests/generator_tests.rs
+++ b/src/schemata/tests/generator_tests.rs
@@ -1,0 +1,204 @@
+#[cfg(test)]
+mod tests {
+    use crate::schemata::SchemataGenerator;
+    use super::*;
+    use crate::xsd::types::{XsdAttribute, XsdComplexType, XsdElement, XsdRestriction, XsdSchema, XsdSimpleType};
+
+    #[test]
+    fn test_new_generator() {
+        let generator = SchemataGenerator::new();
+        assert!(generator.is_ok());
+    }
+
+    #[test]
+    fn test_get_namespaces() {
+        let generator = SchemataGenerator::new().unwrap();
+        let xsd_schema = XsdSchema {
+            target_namespace: Some("http://example.com".to_string()),
+            complex_types: vec![],
+            simple_types: vec![],
+            elements: vec![],
+            imported_schemas: vec![],
+            namespaces: Default::default(),
+        };
+
+        let namespaces = generator.get_namespaces(&xsd_schema);
+        assert_eq!(namespaces.len(), 1);
+        assert_eq!(namespaces[0].name, "http://example.com");
+    }
+
+    #[test]
+    fn test_get_schemas() {
+        let generator = SchemataGenerator::new().unwrap();
+        let complex_types = vec![
+            XsdComplexType {
+                name: Some("TestType".to_string()),
+                sequence: vec![],
+                attributes: vec![],
+                mixed: false,
+            },
+        ];
+
+        let schemas = generator.get_schemas(&complex_types);
+        assert_eq!(schemas.len(), 1);
+        assert_eq!(schemas[0].name, "TestType");
+    }
+
+    #[test]
+    fn test_get_fields() {
+        let generator = SchemataGenerator::new().unwrap();
+        let elements = vec![
+            XsdElement {
+                name: "testField".to_string(),
+                type_name: Some("string".to_string()),
+                min_occurs: Some("0".to_string()),
+                max_occurs: Some("1".to_string()),
+                complex_type: None,
+                simple_type: None,
+                comment: None,
+            },
+        ];
+
+        let fields = generator.get_fields(&elements);
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].name, "testField");
+        assert_eq!(fields[0].type_name, "string");
+        assert!(fields[0].nullable);
+    }
+
+    #[test]
+    fn test_get_enums() {
+        let generator = SchemataGenerator::new().unwrap();
+        let simple_types = vec![
+            XsdSimpleType {
+                name: Some("TestEnum".to_string()),
+                restriction: Some(XsdRestriction {
+                    base: "string".to_string(),
+                    enumeration: vec!["Value1".to_string(), "Value2".to_string()],
+                    pattern: None,
+                    min_inclusive: None,
+                    max_inclusive: None,
+                    min_exclusive: None,
+                    max_exclusive: None,
+                    length: None,
+                    min_length: None,
+                    max_length: None,
+                    total_digits: None,
+                    fraction_digits: None,
+                }),
+                list: None,
+                union: None,
+            },
+        ];
+
+        let enums = generator.get_enums(&simple_types);
+        assert_eq!(enums.len(), 1);
+        assert_eq!(enums[0].name, "TestEnum");
+        assert_eq!(enums[0].values, vec!["Value1".to_string(), "Value2".to_string()]);
+    }
+
+    #[test]
+    fn test_get_annotations() {
+        let generator = SchemataGenerator::new().unwrap();
+        let element = XsdElement {
+            name: "testField".to_string(),
+            type_name: Some("string".to_string()),
+            min_occurs: Some("0".to_string()),
+            max_occurs: Some("unbounded".to_string()),
+            complex_type: None,
+            simple_type: None,
+            comment: None,
+        };
+
+        let annotations = generator.get_annotations(&element);
+        assert_eq!(annotations, "@minOccurs(0) @maxOccurs(unbounded)");
+    }
+
+    #[test]
+    fn test_generate() {
+        let generator = SchemataGenerator::new().unwrap();
+        let xsd_schema = XsdSchema {
+            target_namespace: Some("http://example.com".to_string()),
+            complex_types: vec![
+                XsdComplexType {
+                    name: Some("TestType".to_string()),
+                    sequence: vec![
+                        XsdElement {
+                            name: "testField".to_string(),
+                            type_name: Some("string".to_string()),
+                            min_occurs: Some("0".to_string()),
+                            max_occurs: Some("1".to_string()),
+                            complex_type: None,
+                            simple_type: None,
+                            comment: None,
+                        },
+                    ],
+                    attributes: vec![],
+                    mixed: false,
+                },
+            ],
+            simple_types: vec![
+                XsdSimpleType {
+                    name: Some("TestEnum".to_string()),
+                    restriction: Some(XsdRestriction {
+                        base: "string".to_string(),
+                        enumeration: vec!["Value1".to_string(), "Value2".to_string()],
+                        pattern: None,
+                        min_inclusive: None,
+                        max_inclusive: None,
+                        min_exclusive: None,
+                        max_exclusive: None,
+                        length: None,
+                        min_length: None,
+                        max_length: None,
+                        total_digits: None,
+                        fraction_digits: None,
+                    }),
+                    list: None,
+                    union: None,
+                },
+            ],
+            elements: vec![],
+            imported_schemas: vec![],
+            namespaces: Default::default(),
+        };
+
+        let result = generator.generate(xsd_schema);
+        assert!(result.is_ok());
+
+        let generated_code = result.unwrap();
+
+        // Check for namespace declaration
+        assert!(
+            generated_code.contains("namespace http://example.com") ||
+                generated_code.contains("namespace http://example/com") ||
+                generated_code.contains("namespace http.example.com") ||
+                generated_code.contains("namespace http_example_com"),
+            "Generated code does not contain expected namespace. Generated code:\n{}",
+            generated_code
+        );
+
+        // Check for schema declaration
+        assert!(generated_code.contains("schema TestType"));
+
+        // Check for field declaration
+        assert!(generated_code.contains("testField string"));
+        assert!(generated_code.contains("@minOccurs(0)"));
+        assert!(generated_code.contains("@maxOccurs(1)"));
+
+        // Check for enum declaration
+        assert!(generated_code.contains("enum TestEnum"));
+        assert!(generated_code.contains("Value1"));
+        assert!(generated_code.contains("Value2"));
+
+        // Check for proper formatting
+        assert!(generated_code.contains("}"));  // Closing braces for schema and enum
+
+        // Check that there are no unexpected elements
+        assert!(!generated_code.contains("UnnamedSchema"));
+        assert!(!generated_code.contains("UnnamedEnum"));
+
+        // Print the generated code for debugging
+        println!("Generated Code:\n{}", generated_code);
+    }
+}

--- a/src/schemata/tests/mod.rs
+++ b/src/schemata/tests/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod generator_tests;

--- a/src/schemata/types.rs
+++ b/src/schemata/types.rs
@@ -1,0 +1,32 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct SchemataNamespace {
+    pub name: String,
+    pub schemas: Vec<SchemataSchema>,
+    pub enums: Vec<SchemataEnum>,
+}
+
+#[derive(Serialize)]
+pub struct SchemataSchema {
+    pub name: String,
+    pub comment: Option<String>,
+    pub fields: Vec<SchemataField>,
+}
+
+#[derive(Serialize)]
+pub struct SchemataField {
+    pub name: String,
+    pub type_name: String,
+    pub nullable: bool,
+    pub annotations: String,
+    pub comment: Option<String>,
+    pub inline_schema: Option<SchemataSchema>,
+}
+
+#[derive(Serialize)]
+pub struct SchemataEnum {
+    pub name: String,
+    pub comment: Option<String>,
+    pub values: Vec<String>,
+}

--- a/src/xsd/mod.rs
+++ b/src/xsd/mod.rs
@@ -1,0 +1,4 @@
+mod parser;
+pub mod types;
+mod tests;
+pub use parser::XsdParser;

--- a/src/xsd/parser.rs
+++ b/src/xsd/parser.rs
@@ -1,0 +1,377 @@
+use std::collections::HashMap;
+use quick_xml::events::{Event, BytesStart};
+use quick_xml::reader::Reader;
+use std::io::BufRead;
+
+use super::types::*;
+
+pub struct XsdParser;
+
+impl XsdParser {
+    pub fn parse<R: BufRead>(reader: R) -> Result<XsdSchema, Box<dyn std::error::Error>> {
+        let mut xml_reader = Reader::from_reader(reader);
+        xml_reader.trim_text(true);
+
+        let mut buf = Vec::new();
+        let mut schema = XsdSchema::default();
+        let mut element_stack = Vec::new();
+        let mut namespace_map: HashMap<String, String> = HashMap::new();
+
+        loop {
+            match xml_reader.read_event_into(&mut buf) {
+                Ok(Event::Start(ref e)) => {
+                    match e.local_name().as_ref() {
+                        b"schema" => {
+                            // Capture schema-level attributes and namespaces
+                            schema.target_namespace = Self::get_attribute(e, "targetNamespace", &xml_reader);
+                            // Collect namespace declarations
+                            for attr in e.attributes() {
+                                if let Ok(attr) = attr {
+                                    let key = String::from_utf8_lossy(attr.key.as_ref()).to_string();
+                                    if key.starts_with("xmlns:") {
+                                        let prefix = key.split(':').nth(1).unwrap_or_default();
+                                        if let Ok(value) = attr.decode_and_unescape_value(&xml_reader) {
+                                            namespace_map.insert(prefix.to_string(), value.to_string());
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        b"element" => {
+                            let element = Self::parse_element(e, &mut xml_reader)?;
+                            element_stack.push(element);
+                        },
+                        b"complexType" => {
+                            let complex_type = Self::parse_complex_type(e, &mut xml_reader)?;
+                            if complex_type.name.is_some() {
+                                schema.complex_types.push(complex_type);
+                            } else if let Some(element) = element_stack.last_mut() {
+                                element.complex_type = Some(complex_type);
+                            }
+                        },
+                        b"simpleType" => {
+                            let simple_type = Self::parse_simple_type(e, &mut xml_reader)?;
+                            schema.simple_types.push(simple_type);
+                        },
+                        b"include" | b"import" => {
+                          // Handle schema includes and imports
+                            let schema_location = Self::get_attribute(e, "schemaLocation", &xml_reader);
+                            if let Some(location) = schema_location {
+                                schema.imported_schemas.push(location);
+                            }
+                        },
+                        _ => {
+                            eprintln!("Unhandled top-level element: {:?}",
+                                String::from_utf8_lossy(e.name().as_ref()));
+                        }
+                    }
+                },
+                Ok(Event::End(ref e)) => {
+                    if e.local_name().as_ref() == b"element" {
+                        if let Some(element) = element_stack.pop() {
+                            schema.elements.push(element);
+                        }
+                    }
+                },
+                Ok(Event::Eof) => break,
+                Err(e) => {
+                    eprintln!("Error parsing XML: {:?}", e);
+                    return Err(Box::new(e));
+                },
+                _ => {}
+            }
+            buf.clear();
+        }
+        // Store namespace mappings
+        schema.namespaces = namespace_map;
+        Ok(schema)
+    }
+
+    pub(crate) fn get_attribute<R: BufRead>(e: &BytesStart, attr_name: &str, reader: &Reader<R>) -> Option<String> {
+        e.attributes()
+            .find_map(|a| {
+                let a = a.ok()?;
+                let key = String::from_utf8_lossy(a.key.as_ref());
+                // Handle qualified and unqualified attributes
+                if key == attr_name || key.ends_with(&format!(":{}", attr_name)) {
+                    match a.decode_and_unescape_value(reader) {
+                        Ok(val) => Some(val.into_owned()),
+                        Err(e) => {
+                            eprintln!("Error decoding attribute {}: {:?}", attr_name, e);
+                            None
+                        }
+                    }
+                } else {
+                    None
+                }
+            })
+    }
+
+    pub fn parse_element<R: BufRead>(e: &BytesStart, reader: &mut Reader<R>) -> Result<XsdElement, Box<dyn std::error::Error>> {
+        let mut element = XsdElement {
+            name: Self::get_attribute(e, "name", reader).unwrap_or_default(),
+            type_name: Self::get_attribute(e, "type", reader),
+            min_occurs: Self::get_attribute(e, "minOccurs", reader),
+            max_occurs: Self::get_attribute(e, "maxOccurs", reader),
+            complex_type: None,
+            simple_type: None,
+            comment: None,
+        };
+
+        // Parse nested complex type if present
+        if element.type_name.is_none() {
+            let mut buf = Vec::new();
+            loop {
+                match reader.read_event_into(&mut buf) {
+                    Ok(Event::Start(ref e)) if e.local_name().as_ref() == b"complexType" => {
+                        element.complex_type = Some(Self::parse_complex_type(e, reader)?);
+                        break;
+                    },
+                    Ok(Event::End(ref e)) if e.local_name().as_ref() == b"element" => break,
+                    Ok(Event::Eof) => return Err("Unexpected end of file while parsing <element>".into()),
+                    Err(e) => return Err(Box::new(e)),
+                    _ => {}
+                }
+                buf.clear();
+            }
+        }
+
+        element.comment = Self::extract_comment(reader);
+
+        Ok(element)
+    }
+
+    pub(crate) fn parse_complex_type<R: BufRead>(e: &BytesStart, reader: &mut Reader<R>) -> Result<XsdComplexType, Box<dyn std::error::Error>> {
+        let mut complex_type = XsdComplexType {
+            name: Self::get_attribute(e, "name", reader),
+            sequence: Vec::new(),
+            attributes: Vec::new(),
+            mixed: Self::get_attribute(e, "mixed", reader)
+                .map(|v| v == "true")
+                    .unwrap_or(false),
+        };
+
+        let mut buf = Vec::new();
+        let mut depth = 0;
+        loop {
+            match reader.read_event_into(&mut buf) {
+                Ok(Event::Start(ref e)) => {
+                    depth += 1;
+                    match e.local_name().as_ref() {
+                        b"sequence" => {
+                            complex_type.sequence = Self::parse_sequence(reader)?;
+                        },
+                        b"attribute" => {
+                            if let Ok(attr) = Self::parse_attribute(e, reader) {
+                                complex_type.attributes.push(attr);
+                            }
+                        },
+                        _ => {
+                            println!("Unhandled start element: {:?}", String::from_utf8_lossy(e.local_name().as_ref()));
+                        }
+                    }
+                },
+                Ok(Event::Empty(ref e)) => {
+                    if e.local_name().as_ref() == b"attribute" {
+                        if let Ok(attr) = Self::parse_attribute(e, reader) {
+                            complex_type.attributes.push(attr);
+                        }
+                    }
+                },
+                Ok(Event::End(ref e)) => {
+                    if e.local_name().as_ref() == b"complexType" {
+                        return Ok(complex_type)
+                    }
+                    depth -= 1;
+                },
+                Ok(Event::Eof) => return Err(format!("Unexpected end of file while parsing <complexType> (depth: {})", depth).into()),
+                Err(e) => return Err(Box::new(e)),
+                _ => {}
+            }
+            buf.clear();
+        }
+        Ok(complex_type)
+    }
+
+    pub(crate) fn parse_sequence<R: BufRead>(reader: &mut Reader<R>) -> Result<Vec<XsdElement>, Box<dyn std::error::Error>> {
+        let mut sequence = Vec::new();
+        let mut buf = Vec::new();
+        let mut depth = 0;
+
+        loop {
+            match reader.read_event_into(&mut buf) {
+                Ok(Event::Start(ref start_element)) => {
+                    depth += 1;
+                    if start_element.local_name().as_ref() == b"element" {
+                        if let Ok(element) = Self::parse_element(start_element, reader) {
+                            sequence.push(element);
+                        }
+                    }
+                },
+                Ok(Event::Empty(ref e)) => {
+                  if e.local_name().as_ref() == b"element" {
+                      sequence.push(Self::parse_element(e, reader)?);
+                  }
+                },
+                Ok(Event::End(ref e)) => {
+                    if depth == 0 && e.local_name().as_ref() == b"sequence" {
+                        return Ok(sequence);
+                    }
+                    depth -= 1;
+                },
+                Ok(Event::Eof) => {
+                    return Err(format!("Unexpected end of file while parsing <sequence> (depth: {})", depth).into());
+                },
+                Err(e) => return Err(Box::new(e)),
+                _ => {}
+            }
+            buf.clear();
+        }
+        Ok(sequence)
+    }
+
+    pub(crate) fn parse_attribute<R: BufRead>(e: &BytesStart, reader: &mut Reader<R>) -> Result<XsdAttribute, Box<dyn std::error::Error>> {
+        Ok(XsdAttribute {
+            name: Self::get_attribute(e, "name", reader).unwrap_or_default(),
+            type_name: Self::get_attribute(e, "type", reader).unwrap_or_default(),
+            use_type: Self::get_attribute(e, "use", reader).unwrap_or_default(),
+            default: Self::get_attribute(e, "default", reader),
+            fixed: Self::get_attribute(e, "fixed", reader),
+        })
+    }
+
+    pub(crate) fn parse_simple_type<R: BufRead>(e: &BytesStart, reader: &mut Reader<R>) -> Result<XsdSimpleType, Box<dyn std::error::Error>> {
+        let mut simple_type = XsdSimpleType {
+            name: Self::get_attribute(e, "name", reader),
+            restriction: None,
+            list: None,
+            union: None,
+        };
+
+        let mut buf = Vec::new();
+        loop {
+            match reader.read_event_into(&mut buf) {
+                Ok(Event::Start(ref e)) => {
+                    match e.local_name().as_ref() {
+                        b"restriction" => {
+                            simple_type.restriction = Some(Self::parse_restriction(e, reader)?);
+                        },
+                        b"list" => {
+                          simple_type.list = Self::get_attribute(e, "itemType", reader);
+                        },
+                        b"union" => {
+                            simple_type.union = Self::get_attribute(e, "memberTypes", reader)
+                                .map(|v| v.split_whitespace().map(String::from).collect());
+                        },
+                        _ => {}
+                    }
+                },
+                Ok(Event::End(ref e)) if e.local_name().as_ref() == b"simpleType" => break,
+                Ok(Event::Eof) => return Err("Unexpected end of file while parsing <simpleType>".into()),
+                Err(e) => return Err(Box::new(e)),
+                _ => {}
+            }
+            buf.clear();
+        }
+        Ok(simple_type)
+    }
+
+    pub(crate) fn parse_restriction<R: BufRead>(e: &BytesStart, reader: &mut Reader<R>) -> Result<XsdRestriction, Box<dyn std::error::Error>> {
+        let mut restriction = XsdRestriction {
+            base: Self::get_attribute(e, "base", reader).unwrap_or_default(),
+            enumeration: Vec::new(),
+            pattern: None,
+            min_inclusive: None,
+            max_inclusive: None,
+            min_exclusive: None,
+            max_exclusive: None,
+            length: None,
+            min_length: None,
+            max_length: None,
+            total_digits: None,
+            fraction_digits: None,
+        };
+
+        let mut buf = Vec::new();
+        loop {
+            match reader.read_event_into(&mut buf) {
+                Ok(Event::Empty(ref e)) => {
+                    match e.local_name().as_ref() {
+                        b"enumeration" => {
+                            if let Some(value) = Self::get_attribute(e, "value", reader) {
+                                restriction.enumeration.push(value);
+                            }
+                        },
+                        b"pattern" => {
+                            restriction.pattern = Self::get_attribute(e, "value", reader);
+                        },
+                        b"minInclusive" => {
+                            restriction.min_inclusive = Self::get_attribute(e, "value", reader);
+                        },
+                        b"maxInclusive" => {
+                            restriction.max_inclusive = Self::get_attribute(e, "value", reader);
+                        },
+                        b"minExclusive" => {
+                            restriction.min_exclusive = Self::get_attribute(e, "value", reader);
+                        },
+                        b"maxExclusive" => {
+                            restriction.max_exclusive = Self::get_attribute(e, "value", reader);
+                        },
+                        b"length" => {
+                            restriction.length = Self::get_attribute(e, "value", reader).and_then(|v| v.parse().ok());
+                        },
+                        b"minLength" => {
+                            restriction.min_length = Self::get_attribute(e, "value", reader).and_then(|v| v.parse().ok());
+                        },
+                        b"maxLength" => {
+                            restriction.max_length = Self::get_attribute(e, "value", reader).and_then(|v| v.parse().ok());
+                        },
+                        b"totalDigits" => {
+                            restriction.total_digits = Self::get_attribute(e, "value", reader).and_then(|v| v.parse().ok());
+                        },
+                        b"fractionDigits" => {
+                            restriction.fraction_digits = Self::get_attribute(e, "value", reader).and_then(|v| v.parse().ok());
+                        },
+                        _ => {}
+                    }
+                },
+                Ok(Event::End(ref e)) if e.local_name().as_ref() == b"restriction" => break,
+                Ok(Event::Eof) => return Err("Unexpected end of file".into()),
+                Err(e) => return Err(Box::new(e)),
+                _ => {}
+            }
+            buf.clear();
+        }
+        Ok(restriction)
+    }
+
+    pub(crate) fn extract_comment<R: BufRead>(reader: &mut Reader<R>) -> Option<String> {
+        // TODO: Implement extraction logic
+        None
+    }
+
+    fn log_parsing_progress(element: &str, details: Option<&str>) {
+        if cfg!(debug_assertions) {
+            let detail_str = details.unwrap_or("No details");
+            println!("Parsing {}: {}", element, detail_str);
+        }
+    }
+}
+
+trait XsdParserError: std::error::Error {
+    fn get_context(&self) -> String;
+}
+
+#[derive(Debug)]
+struct XsdParsingError {
+    message: String,
+    context: String,
+}
+
+impl std::fmt::Display for XsdParsingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "XSD Parsing Error: {} (Context: {})", self.message, self.context)
+    }
+}
+
+impl std::error::Error for XsdParsingError {}

--- a/src/xsd/tests/mod.rs
+++ b/src/xsd/tests/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod parser_tests;

--- a/src/xsd/tests/parser_tests.rs
+++ b/src/xsd/tests/parser_tests.rs
@@ -1,0 +1,177 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::xsd::XsdParser;
+    use quick_xml::events::Event;
+    use quick_xml::reader::Reader;
+    use std::io::BufReader;
+
+    // Helper function to create a Reader from a string
+    fn create_reader(xml: &str) -> Reader<BufReader<&[u8]>> {
+        let mut reader = Reader::from_reader(BufReader::new(xml.as_bytes()));
+        reader.trim_text(true);
+        reader
+    }
+
+    #[test]
+    fn test_get_attribute() {
+        let xml = r#"<xs:element xmlns:xs="http://www.w3.org/2001/XMLSchema" name="test" type="string" />"#;
+        let mut reader = create_reader(xml);
+        let mut buf = Vec::new();
+
+        let event = reader.read_event_into(&mut buf).expect("Failed to read event");
+
+        match event {
+            Event::Start(e) | Event::Empty(e) => {
+                assert_eq!(
+                    XsdParser::get_attribute(&e, "name", &reader),
+                    Some("test".to_string())
+                );
+                assert_eq!(
+                    XsdParser::get_attribute(&e, "type", &reader),
+                    Some("string".to_string())
+                );
+                assert_eq!(XsdParser::get_attribute(&e, "nonexistent", &reader), None);
+            }
+            _ => panic!("Unexpected event type"),
+        }
+    }
+
+    #[test]
+    fn test_parse_element() {
+        let xml = r#"<xs:element xmlns:xs="http://www.w3.org/2001/XMLSchema" name="test" type="xs:string" minOccurs="0" maxOccurs="unbounded" />"#;
+        let mut reader = create_reader(xml);
+        let mut buf = Vec::new();
+
+        let event = reader.read_event_into(&mut buf).expect("Failed to read event");
+
+        match event {
+            Event::Start(e) | Event::Empty(e) => {
+                let element =
+                    XsdParser::parse_element(&e, &mut reader).expect("Failed to parse element");
+                assert_eq!(element.name, "test");
+                assert_eq!(element.type_name, Some("xs:string".to_string()));
+                assert_eq!(element.min_occurs, Some("0".to_string()));
+                assert_eq!(element.max_occurs, Some("unbounded".to_string()));
+            }
+            _ => panic!("Unexpected event type"),
+        }
+    }
+
+    #[test]
+    fn test_parse_complex_type_with_nested_elements() {
+        let xml = r#"
+        <xs:complexType xmlns:xs="http://www.w3.org/2001/XMLSchema" name="TestType">
+            <xs:sequence>
+                <xs:element name="child1" type="xs:string" />
+                <xs:element name="child2" type="xs:int" minOccurs="0" />
+            </xs:sequence>
+            <xs:attribute name="testAttr" type="xs:boolean" use="optional" />
+        </xs:complexType>
+        "#.trim();
+
+        let mut reader = create_reader(xml);
+        let mut buf = Vec::new();
+
+        let event = reader.read_event_into(&mut buf).expect("Failed to read event");
+
+        match event {
+            Event::Start(e) => {
+                let complex_type = XsdParser::parse_complex_type(&e, &mut reader)
+                    .expect("Failed to parse complex type");
+
+                // Debug print to understand what's happening
+                println!("Sequence length: {}", complex_type.sequence.len());
+                println!("Attributes length: {}", complex_type.attributes.len());
+
+                assert_eq!(complex_type.name, Some("TestType".to_string()));
+
+                // Verify sequence
+                assert_eq!(
+                    complex_type.sequence.len(),
+                    2,
+                    "Sequence should contain 2 elements"
+                );
+                assert_eq!(complex_type.sequence[0].name, "child1");
+                assert_eq!(
+                    complex_type.sequence[0].type_name,
+                    Some("xs:string".to_string())
+                );
+                assert_eq!(complex_type.sequence[1].name, "child2");
+                assert_eq!(
+                    complex_type.sequence[1].type_name,
+                    Some("xs:int".to_string())
+                );
+
+                // Verify attributes
+                assert_eq!(complex_type.attributes.len(), 1, "Should have 1 attribute");
+                assert_eq!(complex_type.attributes[0].name, "testAttr");
+                assert_eq!(complex_type.attributes[0].type_name, "xs:boolean");
+                assert_eq!(complex_type.attributes[0].use_type, "optional");
+            }
+            _ => panic!("Unexpected event type"),
+        }
+    }
+
+    #[test]
+    fn test_parse_simple_type_with_complex_restriction() {
+        let xml = r#"
+        <xs:simpleType xmlns:xs="http://www.w3.org/2001/XMLSchema" name="TestEnum">
+            <xs:restriction base="xs:string">
+                <xs:enumeration value="One" />
+                <xs:enumeration value="Two" />
+                <xs:enumeration value="Three" />
+                <xs:length value="3" />
+                <xs:pattern value="[A-Z][a-z][a-z]" />
+            </xs:restriction>
+        </xs:simpleType>
+        "#
+        .trim();
+        let mut reader = create_reader(xml);
+        let mut buf = Vec::new();
+        if let Ok(Event::Start(e)) = reader.read_event_into(&mut buf) {
+            let simple_type = XsdParser::parse_simple_type(&e, &mut reader).unwrap();
+            assert_eq!(simple_type.name, Some("TestEnum".to_string()));
+            assert!(simple_type.restriction.is_some());
+
+            let restriction = simple_type.restriction.unwrap();
+            assert_eq!(restriction.base, "xs:string");
+            assert_eq!(restriction.enumeration, vec!["One", "Two", "Three"]);
+
+            // Additional restriction details
+            assert_eq!(restriction.length, Some(3));
+            assert_eq!(restriction.pattern, Some("[A-Z][a-z][a-z]".to_string()));
+        } else {
+            panic!("Failed to parse XML");
+        }
+    }
+
+    #[test]
+    fn test_parse_schema_with_namespaces() {
+        let xml = r#"
+        <xs:schema
+            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns:my="http://example.com/namespace"
+            targetNamespace="http://example.com/test">
+            <xs:element name="testElement" type="my:TestType" />
+        </xs:schema>
+        "#
+        .trim();
+
+        let reader = BufReader::new(xml.as_bytes());
+        let schema = XsdParser::parse(reader).unwrap();
+
+        assert_eq!(
+            schema.target_namespace,
+            Some("http://example.com/test".to_string())
+        );
+
+        // Verify namespace map
+        assert!(schema.namespaces.contains_key("xs"));
+        assert!(schema.namespaces.contains_key("my"));
+        assert_eq!(
+            schema.namespaces.get("xs"),
+            Some(&"http://www.w3.org/2001/XMLSchema".to_string())
+        );
+    }
+}

--- a/src/xsd/types.rs
+++ b/src/xsd/types.rs
@@ -1,0 +1,64 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Default)]
+pub struct XsdSchema {
+    pub target_namespace: Option<String>,
+    pub elements: Vec<XsdElement>,
+    pub complex_types: Vec<XsdComplexType>,
+    pub simple_types: Vec<XsdSimpleType>,
+    // Add other top-level components as needed
+    pub namespaces: HashMap<String, String>,
+    pub imported_schemas: Vec<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct XsdElement {
+    pub name: String,
+    pub type_name: Option<String>,
+    pub min_occurs: Option<String>,
+    pub max_occurs: Option<String>,
+    pub complex_type: Option<XsdComplexType>,
+    pub simple_type: Option<XsdSimpleType>,
+    pub comment: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct XsdAttribute {
+    pub name: String,
+    pub type_name: String,
+    pub use_type: String,
+    pub default: Option<String>,
+    pub fixed: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct XsdComplexType {
+    pub name: Option<String>,
+    pub sequence: Vec<XsdElement>,
+    pub attributes: Vec<XsdAttribute>,
+    pub mixed: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct XsdSimpleType {
+    pub name: Option<String>,
+    pub restriction: Option<XsdRestriction>,
+    pub list: Option<String>,
+    pub union: Option<Vec<String>>,
+}
+
+#[derive(Debug, Default)]
+pub struct XsdRestriction {
+    pub base: String,
+    pub enumeration: Vec<String>,
+    pub pattern: Option<String>,
+    pub min_inclusive: Option<String>,
+    pub max_inclusive: Option<String>,
+    pub min_exclusive: Option<String>,
+    pub max_exclusive: Option<String>,
+    pub length: Option<usize>,
+    pub min_length: Option<usize>,
+    pub max_length: Option<usize>,
+    pub total_digits: Option<usize>,
+    pub fraction_digits: Option<usize>,
+}

--- a/templates/schemata/schema.tera
+++ b/templates/schemata/schema.tera
@@ -1,0 +1,30 @@
+{% for ns in namespaces %}
+namespace {{ ns.name }};
+
+{% for schema in ns.schemas %}
+{% if schema.comment %}# {{ schema.comment }}{% endif %}
+schema {{ schema.name }} {
+    {% for field in schema.fields %}
+    {{ field.name }} {{ field.type_name }}{% if field.nullable %}?{% endif %}{% if field.annotations %} {{ field.annotations }}{% endif %}{% if field.comment %} # {{ field.comment }}{% endif %}
+    {% if field.inline_schema %}
+    schema {
+        {% for inline_field in field.inline_schema.fields %}
+        {{ inline_field.name }} {{ inline_field.type_name }}{% if inline_field.nullable %}?{% endif %}{% if inline_field.annotations %} {{ inline_field.annotations }}{% endif %}{% if inline_field.comment %} # {{ inline_field.comment }}{% endif %}
+        {% endfor %}
+    }
+    {% endif %}
+    {% endfor %}
+}
+
+{% endfor %}
+
+{% for enum in ns.enums %}
+{% if enum.comment %}# {{ enum.comment }}{% endif %}
+enum {{ enum.name }} {
+    {% for value in enum.values %}
+    {{ value }},
+    {% endfor %}
+}
+
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
BREAKING CHANGE: The functions in the xsd parser are generic to allow for BufReader of various types

re #2